### PR TITLE
Update Nl2br.php

### DIFF
--- a/src/Filters/Nl2br.php
+++ b/src/Filters/Nl2br.php
@@ -11,7 +11,7 @@ class Nl2br
 {
     public static bool $xhtml = false;
 
-    public static function handle(string $text, bool $xhtml = null): Html
+    public static function handle(string $text, ?bool $xhtml = null): Html
     {
         return new Html(nl2br($text, $xhtml ?? self::$xhtml));
     }


### PR DESCRIPTION
PHP 8.4: Implicitly nullable parameter declarations deprecated