### PR TITLE
Add Laravel file loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,25 @@ Follow the instructions in the config file.
 
 And that's it! If you want more control, [override the service provider](#custom-extension).
 
+### Laravel view file loader
+
+By default, Latte uses its native filesystem loader. To resolve includes like Laravel views, enable the Laravel loader:
+
+```php
+// config/latte.php
+'loader' => 'laravel', // default: 'nette'
+```
+
+```html
+{* resources/views/users/index.latte *}
+
+{include partials.card, user: $user}  {* resources/views/partials/card.latte *}
+{include file dashboard}              {* resources/views/dashboard.latte *}
+{include ./card.latte}                {* resources/views/users/card.latte *}
+```
+
+Dotted names use Laravel view resolution. Path-like names (`./`, `../`, `/`) stay relative or absolute filesystem paths. Use `{include file foo}` for root views, because `{include foo}` means block `foo` in Latte.
+
 ## Extension
 
 The following features are not available in native Latte or behave differently (e.g., tags `{link}`, `{asset}` or translations).

--- a/config/latte.php
+++ b/config/latte.php
@@ -21,6 +21,21 @@ return [
 
     /*
     |---------------------------------------------------------------------------
+    | Template Loader
+    |---------------------------------------------------------------------------
+    |
+    | The default "nette" loader keeps Latte's native filesystem behavior.
+    | The optional "laravel" loader resolves dotted and namespaced view names
+    | through Laravel's view finder, including registered view paths and hints.
+    |
+    | Supported values: "nette", "laravel", or a class implementing Latte\Loader.
+    |
+    */
+
+    'loader' => 'nette',
+
+    /*
+    |---------------------------------------------------------------------------
     | XHTML or HTML
     |---------------------------------------------------------------------------
     |

--- a/src/Loaders/LaravelLoader.php
+++ b/src/Loaders/LaravelLoader.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Miko\LaravelLatte\Loaders;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\Factory;
+use Illuminate\View\FileViewFinder;
+use Illuminate\View\ViewFinderInterface;
+use Illuminate\View\ViewName;
+use Latte\Loader;
+use Latte\RuntimeException;
+use Latte\TemplateNotFoundException;
+use Throwable;
+use function array_pop;
+use function end;
+use function explode;
+use function implode;
+use function preg_match;
+use function str_starts_with;
+use function strtr;
+use const DIRECTORY_SEPARATOR;
+
+class LaravelLoader implements Loader
+{
+    public function __construct(
+        protected Factory $view
+    ) {}
+
+    public function finder(): ViewFinderInterface
+    {
+        return $this->view->getFinder();
+    }
+
+    public function filesystem(): Filesystem
+    {
+        $finder = $this->finder();
+        if ($finder instanceof FileViewFinder) {
+            return $finder->getFilesystem();
+        }
+
+        throw new RuntimeException('Latte requires a file-based view finder.');
+    }
+
+    public function getContent(string $name): string
+    {
+        $file = $this->resolve($name);
+
+        if (! $this->filesystem()->isFile($file)) {
+            throw new TemplateNotFoundException("Missing template file '$file'.");
+        }
+
+        try {
+            return $this->filesystem()->get($file);
+        } catch (Throwable $e) {
+            throw new RuntimeException("Unable to read file '$file'.", previous: $e);
+        }
+    }
+
+    public function isExpired(string $path, int $time): bool
+    {
+        try {
+            return $this->filesystem()->lastModified($path) > $time;
+        } catch (Throwable) {
+            return true;
+        }
+    }
+
+    public function getReferredName(string $name, string $referringFile): string
+    {
+        return $this->resolve($name, $referringFile);
+    }
+
+    public function getUniqueId(string $name): string
+    {
+        return strtr($this->resolve($name), '/', DIRECTORY_SEPARATOR);
+    }
+
+    protected function resolve(string $name, ?string $context = null): string
+    {
+        if ($this->looksLikePath($name)) {
+            return $this->normalizePath($this->isRelativePath($name) && $context
+                ? dirname($context) . '/' . $name
+                : $name);
+        }
+
+        return $this->findViewPath($name);
+    }
+
+    protected function looksLikePath(string $name): bool
+    {
+        return str_starts_with($name, '/')
+            || str_starts_with($name, './')
+            || str_starts_with($name, '../')
+            || preg_match('#^[a-z]:[\\/]#i', $name) === 1
+            || str_starts_with($name, 'phar://');
+    }
+
+    protected function isRelativePath(string $name): bool
+    {
+        return str_starts_with($name, './') || str_starts_with($name, '../');
+    }
+
+    protected function findViewPath(string $name): string
+    {
+        $name = $this->normalizeViewName($name);
+
+        try {
+            return $this->finder()->find($name);
+        } catch (Throwable $e) {
+            throw new TemplateNotFoundException("Missing template view '$name'.", previous: $e);
+        }
+    }
+
+    protected function normalizeViewName(string $name): string
+    {
+        return ViewName::normalize($name);
+    }
+
+    protected function normalizePath(string $path): string
+    {
+        preg_match('#^([a-z]:|phar://.+?/)?(.*)#i', $path, $m) ?: throw new \LogicException;
+
+        $res = [];
+        foreach (explode('/', strtr($m[2], '\\', '/')) as $part) {
+            if ($part === '..' && $res && end($res) !== '..' && end($res) !== '') {
+                array_pop($res);
+            } elseif ($part !== '.') {
+                $res[] = $part;
+            }
+        }
+
+        return $m[1] . implode(DIRECTORY_SEPARATOR, $res);
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -6,9 +6,12 @@ namespace Miko\LaravelLatte;
 
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Foundation\Application;
+use InvalidArgumentException;
+use Miko\LaravelLatte\Loaders\LaravelLoader;
 use Latte\Bridges\Tracy\TracyExtension;
 use Latte\Engine as Latte;
 use Latte\Feature;
+use Latte\Loader;
 use Latte\Runtime\Template;
 use Livewire\LivewireManager;
 
@@ -70,12 +73,37 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $latte->setFeature(Feature::ScopedLoopVariables, $config->get('latte.scoped_loop_variables'));
         $latte->setFeature(Feature::Dedent, $config->get('latte.dedent'));
         $latte->setFeature(Feature::MigrationWarnings, $this->decideMigrationWarnings());
+        $this->configureLoader($latte);
 
         $latte->addProvider('coreParentFinder', function (Template $template) use ($config) {
             if (!$template->getReferenceType() && $layout = $config->get('latte.layout')) {
                 return $layout;
             }
         });
+    }
+
+    protected function configureLoader(Latte $latte): void
+    {
+        $loader = $this->config->get('latte.loader', 'nette');
+
+        if ($loader === null || $loader === 'nette') {
+            return;
+        }
+
+        if ($loader === 'laravel') {
+            $latte->setLoader(new LaravelLoader($this->app->get('view')));
+            return;
+        }
+
+        if (is_string($loader) && class_exists($loader)) {
+            $loader = $this->app->make($loader);
+        }
+
+        if (! $loader instanceof Loader) {
+            throw new InvalidArgumentException('Latte loader must be "nette", "laravel", or a class implementing ' . Loader::class . '.');
+        }
+
+        $latte->setLoader($loader);
     }
 
     protected function decideAutoRefresh(): bool

--- a/tests/Fixtures/CustomLoader.php
+++ b/tests/Fixtures/CustomLoader.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Miko\LaravelLatte\Tests\Fixtures;
+
+use Latte\Loader;
+
+class CustomLoader implements Loader
+{
+    public function getContent(string $name): string
+    {
+        return 'Custom loader';
+    }
+
+    public function getReferredName(string $name, string $referringName): string
+    {
+        return $name;
+    }
+
+    public function getUniqueId(string $name): string
+    {
+        return $name;
+    }
+}

--- a/tests/LaravelLoaderTest.php
+++ b/tests/LaravelLoaderTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Miko\LaravelLatte\Tests;
+
+use Latte\Engine as Latte;
+use Latte\Loaders\FileLoader;
+use Latte\TemplateNotFoundException;
+use Miko\LaravelLatte\Loaders\LaravelLoader;
+use Miko\LaravelLatte\Tests\Fixtures\CustomLoader;
+
+class LaravelLoaderTest extends TestCase
+{
+    public function test_not_configured_loader_uses_nette_loader(): void
+    {
+        $loader = $this->app->get(Latte::class)->getLoader();
+
+        $this->assertInstanceOf(FileLoader::class, $loader);
+    }
+
+    public function test_configured_laravel_loader(): void
+    {
+        $this->app['config']->set('latte.loader', 'laravel');
+
+        $loader = $this->app->get(Latte::class)->getLoader();
+
+        $this->assertInstanceOf(LaravelLoader::class, $loader);
+    }
+
+    public function test_configured_custom_loader(): void
+    {
+        $this->app['config']->set('latte.loader', CustomLoader::class);
+
+        $loader = $this->app->get(Latte::class)->getLoader();
+
+        $this->assertInstanceOf(CustomLoader::class, $loader);
+    }
+
+    public function test_default_nette_loader_does_not_resolve_laravel_dotted_includes(): void
+    {
+        $this->expectException(TemplateNotFoundException::class);
+
+        view('laravel-loader/default-nette')->render();
+    }
+
+    public function test_laravel_file_loader_resolves_referred_names(): void
+    {
+        $loader = $this->loader();
+        $referringFile = resource_path('views/laravel-loader/index.latte');
+
+        $this->app['view']->addNamespace('laravel-loader', resource_path('views/vendor/laravel-loader'));
+        $this->app['view']->addLocation(base_path('alternate-views'));
+
+        $this->assertSame(
+            resource_path('views/foo.latte'),
+            $loader->getReferredName('foo', $referringFile)
+        );
+        $this->assertSame(
+            resource_path('views/laravel-loader/partials/card.latte'),
+            $loader->getReferredName('laravel-loader.partials.card', $referringFile)
+        );
+        $this->assertSame(
+            resource_path('views/vendor/laravel-loader/namespaced.latte'),
+            $loader->getReferredName('laravel-loader::namespaced', $referringFile)
+        );
+        $this->assertSame(
+            base_path('alternate-views/alternate/location.latte'),
+            $loader->getReferredName('alternate.location', $referringFile)
+        );
+        $this->assertSame(
+            resource_path('views/laravel-loader/relative-fragment.latte'),
+            $loader->getReferredName('./relative-fragment.latte', $referringFile)
+        );
+        $this->assertSame(
+            resource_path('views/laravel-loader/foo.bar'),
+            $loader->getReferredName('./foo.bar', $referringFile)
+        );
+        $this->assertSame(
+            resource_path('views/laravel-loader/absolute-fragment.latte'),
+            $loader->getReferredName(resource_path('views/laravel-loader/absolute-fragment.latte'), $referringFile)
+        );
+    }
+
+    public function test_laravel_file_loader_reads_content(): void
+    {
+        $loader = $this->loader();
+
+        $this->assertSame("CARD {\$title}\n", $loader->getContent('laravel-loader.partials.card'));
+        $this->assertSame("ABSOLUTE\n", $loader->getContent(resource_path('views/laravel-loader/absolute-fragment.latte')));
+        $this->assertSame(
+            resource_path('views/laravel-loader/partials/card.latte'),
+            $loader->getUniqueId('laravel-loader.partials.card')
+        );
+    }
+
+    public function test_laravel_loader_renders_templates_with_laravel_view_resolution(): void
+    {
+        $this->app['config']->set('latte.loader', 'laravel');
+        $this->app['view']->addNamespace('laravel-loader', resource_path('views/vendor/laravel-loader'));
+        $this->app['view']->addLocation(base_path('alternate-views'));
+
+        $output = view('laravel-loader.index', [
+            'title' => 'Blade Style',
+            'absoluteView' => resource_path('views/laravel-loader/absolute-fragment.latte'),
+        ])->render();
+
+        $expected = <<<HTML
+        A:BLOCK Blade Style
+        B:CARD Blade Style
+
+        C:RELATIVE
+
+        D:ABSOLUTE
+
+        E:NAMESPACE Blade Style
+
+        F:LOCATION Blade Style
+
+        G:ROOT Blade Style
+        HTML;
+
+        $this->assertSame($expected, trim($output));
+    }
+
+    private function loader(): LaravelLoader
+    {
+        return new LaravelLoader($this->app->get('view'));
+    }
+}

--- a/tests/laravel/alternate-views/alternate/location.latte
+++ b/tests/laravel/alternate-views/alternate/location.latte
@@ -1,0 +1,1 @@
+LOCATION {$title}

--- a/tests/laravel/resources/views/foo.latte
+++ b/tests/laravel/resources/views/foo.latte
@@ -1,0 +1,1 @@
+ROOT {$title}

--- a/tests/laravel/resources/views/laravel-loader/absolute-fragment.latte
+++ b/tests/laravel/resources/views/laravel-loader/absolute-fragment.latte
@@ -1,0 +1,1 @@
+ABSOLUTE

--- a/tests/laravel/resources/views/laravel-loader/default-nette.latte
+++ b/tests/laravel/resources/views/laravel-loader/default-nette.latte
@@ -1,0 +1,1 @@
+{layout none}{include laravel-loader.partials.card, title: 'Fail'}

--- a/tests/laravel/resources/views/laravel-loader/index.latte
+++ b/tests/laravel/resources/views/laravel-loader/index.latte
@@ -1,0 +1,8 @@
+{layout none}{define foo}BLOCK {$title}{/define}
+A:{include foo}
+B:{include laravel-loader.partials.card, title: $title}
+C:{include ./relative-fragment.latte}
+D:{include $absoluteView}
+E:{include 'laravel-loader::namespaced', value: $title}
+F:{include alternate.location, title: $title}
+G:{include file foo, title: $title}

--- a/tests/laravel/resources/views/laravel-loader/partials/card.latte
+++ b/tests/laravel/resources/views/laravel-loader/partials/card.latte
@@ -1,0 +1,1 @@
+CARD {$title}

--- a/tests/laravel/resources/views/laravel-loader/relative-fragment.latte
+++ b/tests/laravel/resources/views/laravel-loader/relative-fragment.latte
@@ -1,0 +1,1 @@
+RELATIVE

--- a/tests/laravel/resources/views/vendor/laravel-loader/namespaced.latte
+++ b/tests/laravel/resources/views/vendor/laravel-loader/namespaced.latte
@@ -1,0 +1,1 @@
+NAMESPACE {$value}


### PR DESCRIPTION
Add an optional Laravel-backed Latte file loader for Blade-style view resolution. Closes #8.

## Config

```php
// config/latte.php

'loader' => 'laravel', // default: 'nette'
```

Supported values:

- `'nette'` keeps Latte's native filesystem loader.
- `'laravel'` resolves Latte templates through Laravel's view finder.
- A custom class name implementing `Latte\Loader` can be provided.

## Usage 

```latte
{include partials.card}             {* resources/views/partials/card.latte *}
{include 'admin::menu'}             {* namespaced Laravel view hint *}
{include ./card.latte}              {* path relative to current template *}
{include resource_path('views/card.latte')}
```

Important distinction:

```latte
{include foo.bar}    {* Laravel view: resources/views/foo/bar.latte *}
{include ./foo.bar}  {* literal relative path: ./foo.bar *}
```

## Ambiguous paths

If there's ambiguity about whether you want to include a file or a block, use the `file` or `block` keywords supported by Latte for clarification:

```latte
{include file foo}    {* resources/views/foo.latte *}
{include block foo}   {* #foo block from current file *}
```

## Decisions as discussed

- Default behavior remains unchanged: `latte.loader` defaults to `'nette'`
- No custom `{view}` / `{includeview}` tag is added
- Existing Latte include semantics stay intact: `{include foo}` still targets block `foo`
- Root views can be included explicitly via `{include file foo}`
- Laravel and Nette loaders are mutually exclusive; there is no fallback chain
- Dotted view names and namespaced hints use Laravel's `ViewFinderInterface`
- Path-like references (`./`, `../`, `/`, absolute paths) stay path-based and are not dot-normalized

## Tests

- Loader config selection: default Nette, Laravel loader, custom loader class
- Isolated loader behavior via `getReferredName`, `getContent`, and `getUniqueId`
- Rendering behavior for dotted includes, namespaced hints, extra view locations, relative and absolute paths
